### PR TITLE
Add skills section and update OpenRaven company name

### DIFF
--- a/index.html
+++ b/index.html
@@ -438,7 +438,7 @@ blockquote,
                 <div class="row">
                   <div class="details">
                     <div class="where">
-                      Open Raven
+                      OpenRaven (acquired by Intellistack)
                     </div>
                     <div class="year">July 2020 – June 2024</div>
                   </div>
@@ -720,6 +720,60 @@ blockquote,
                 </div>
               </li>
             </ul>
+          </div>
+          <!-- SKILLS -->
+          <div class="box">
+            <h2><i class="fas fa-tasks ico"></i> Skills</h2>
+            <div class="skills clearfix">
+              <div class="item-skills">
+                  AI
+                  
+              </div>
+              <div class="col-sm-offset-1 col-sm-12 clearfix">
+                <span class= "skill badge">Spring AI</span>
+                <span class= "skill badge">Codex</span>
+                <span class= "skill badge">Claude</span>
+                <span class= "skill badge">Cursor</span>
+              </div>
+            </div>
+            <div class="skills clearfix">
+              <div class="item-skills">
+                  Backend
+                  
+              </div>
+              <div class="col-sm-offset-1 col-sm-12 clearfix">
+                <span class= "skill badge">Java / JVM languages</span>
+                <span class= "skill badge">Spring</span>
+                <span class= "skill badge">RDBMS (PostgreSQL, MySQL)</span>
+                <span class= "skill badge">Redis</span>
+                <span class= "skill badge">ElasticSearch</span>
+              </div>
+            </div>
+            <div class="skills clearfix">
+              <div class="item-skills">
+                  Cloud &amp; DevOps
+                  
+              </div>
+              <div class="col-sm-offset-1 col-sm-12 clearfix">
+                <span class= "skill badge">AWS</span>
+                <span class= "skill badge">Google Cloud Platform (GCP)</span>
+                <span class= "skill badge">Kubernetes</span>
+                <span class= "skill badge">Docker</span>
+                <span class= "skill badge">Serverless</span>
+                <span class= "skill badge">CI/CD Pipelines</span>
+              </div>
+            </div>
+            <div class="skills clearfix">
+              <div class="item-skills">
+                  Architecture &amp; Tooling
+                  
+              </div>
+              <div class="col-sm-offset-1 col-sm-12 clearfix">
+                <span class= "skill badge">System Design</span>
+                <span class= "skill badge">API Design</span>
+                <span class= "skill badge">Microservices</span>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -438,7 +438,7 @@ blockquote,
                 <div class="row">
                   <div class="details">
                     <div class="where">
-                      OpenRaven (acquired by Intellistack)
+                      Open Raven (acquired by Intellistack)
                     </div>
                     <div class="year">July 2020 – June 2024</div>
                   </div>

--- a/resume.json
+++ b/resume.json
@@ -39,7 +39,7 @@
       ]
     },
     {
-      "name": "OpenRaven (acquired by Intellistack)",
+      "name": "Open Raven (acquired by Intellistack)",
       "position": "Senior Software Engineer / Technical Director",
       "startDate": "2020-07",
       "endDate": "2024-06",

--- a/resume.json
+++ b/resume.json
@@ -39,7 +39,7 @@
       ]
     },
     {
-      "name": "Open Raven",
+      "name": "OpenRaven (acquired by Intellistack)",
       "position": "Senior Software Engineer / Technical Director",
       "startDate": "2020-07",
       "endDate": "2024-06",
@@ -136,6 +136,24 @@
       "position": "Senior Software Engineer",
       "startDate": "1996-11",
       "endDate": "1999-01"
+    }
+  ],
+  "skills": [
+    {
+      "name": "AI",
+      "keywords": ["Spring AI", "Codex", "Claude", "Cursor"]
+    },
+    {
+      "name": "Backend",
+      "keywords": ["Java / JVM languages", "Spring", "RDBMS (PostgreSQL, MySQL)", "Redis", "ElasticSearch"]
+    },
+    {
+      "name": "Cloud & DevOps",
+      "keywords": ["AWS", "Google Cloud Platform (GCP)", "Kubernetes", "Docker", "Serverless", "CI/CD Pipelines"]
+    },
+    {
+      "name": "Architecture & Tooling",
+      "keywords": ["System Design", "API Design", "Microservices"]
     }
   ],
   "education": [


### PR DESCRIPTION
## Summary

- Adds a Skills section to the resume (right column, below Education) with four categories pulled from Notion Work History | Skills: AI, Backend, Cloud & DevOps, Architecture & Tooling
- Updates the OpenRaven job header to "OpenRaven (acquired by Intellistack)"
- `index.html` regenerated from `resume.json` via `resumed`

## After merge

Update the public Gist to stay in sync:
```
gh gist edit b646ec02fe5b675e87cef0059a8e0892 resume.json
```

## Test plan

- [ ] Open `index.html` in a browser and confirm Skills section appears below Education with styled skill tags
- [ ] Confirm OpenRaven entry shows "OpenRaven (acquired by Intellistack)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)